### PR TITLE
Renamed plugin to readyapi-testengine-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# ReadyAPI TestServer Maven Plugin
+# ReadyAPI TestEngine Maven Plugin
 
-A maven plugin that runs a set of Ready! API TestServer Json recipes and Ready! API projects - 
+A maven plugin that runs a set of SoapUI/ReadyAPI projects with ReadyAPI TestEngine - 
 configure it to run in whatever build phase you might find relevant, for example;
 
 ```
 <plugin>
     <groupId>com.smartbear.readyapi</groupId>
-    <artifactId>testserver-maven-plugin</artifactId>
+    <artifactId>testengine-maven-plugin</artifactId>
     <version>1.0.1</version>
     <configuration>
         <username>defaultUser</username>
         <password>defaultPassword</password>
-        <server>...Ready!API TestServer endpoint...</server>
+        <server>...ReadyAPI TestEngine endpoint...</server>
     </configuration>
     <executions>
         <execution>
@@ -28,7 +28,7 @@ configure it to run in whatever build phase you might find relevant, for example
 The only goal exposed by the plugin is "run" - you can invoke it as above or directly from the command-line, for example
 
 ```
-mvn testserver:run 
+mvn testengine:run 
 ```
 
 The plugin will look for files with either json or xml extensions.
@@ -37,9 +37,9 @@ The plugin will look for files with either json or xml extensions.
 
 Configuration parameters are:
 
-* username (required) : the TestServer username to use for authentication
-* password (required) : the TestServer password to use for authentication
-* server (required) : endpoint of the TestServer (no trailing slash!)
+* username (required) : the TestEngine username to use for authentication
+* password (required) : the TestEngine password to use for authentication
+* server (required) : endpoint of the TestEngine (no trailing slash!)
 * recipeDirectory : the folder to scan recursively for recipes/projects, defaults to ${project.basedir}/src/test/resources/recipes
 * targetDirectory : the folder to which filtered recipes will be copied before executing, defaults
 to ${project.basedir}/target/test-recipes
@@ -52,7 +52,7 @@ the surefire plugin), defaults to ${basedir}/target/surefire-reports
 to target
 * async : toggle if tests should be executed asynchronously - default is false which will wait for tests to finish 
  to be able to create test-reports. Setting this to true will disable reporting functionality, but allow you 
-to specify an optional callback that will be called by the TestServer with test results when they are finished.
+to specify an optional callback that will be called by the TestEngine with test results when they are finished.
 * callback : an optional url to call with finished test results if async is set to true 
 
 Specifying a skipApiTests system property will bypass this plugin altogether.
@@ -98,7 +98,7 @@ actually executed.
 
 ## Error reporting
 
-Currently the plugin simple fails the build if any tests fail and dumps the Ready!API TestServer 
+Currently the plugin simple fails the build if any tests fail and dumps the ReadyAPI TestEngine 
 response to the console. A surefire xml file is generated for inclusion in generated reports.
 
 ## Building the plugin

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.smartbear.readyapi</groupId>
-    <artifactId>testserver-maven-plugin</artifactId>
+    <artifactId>testengine-maven-plugin</artifactId>
 
     <packaging>maven-plugin</packaging>
     <version>1.0.1-SNAPSHOT</version>
-    <name>Ready! API TestServer Maven Plugin</name>
+    <name>ReadyAPI TestEngine Maven Plugin</name>
 
-    <description>Maven plugin for executing test recipes against Ready!API TestServer</description>
-    <url>https://github.com/olensmar/readyapi-testserver-maven-plugin</url>
+    <description>Maven plugin for executing test projects with ReadyAPI TestEngine</description>
+    <url>https://github.com/readyapi/readyapi-testengine-maven-plugin</url>
 
     <developers>
         <developer>
@@ -19,15 +19,15 @@
     </developers>
 
     <scm>
-        <url>https://github.com/olensmar/readyapi-testserver-maven-plugin</url>
-        <connection>scm:git:ssh://git@github.com/olensmar/readyapi-testserver-maven-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/olensmar/readyapi-testserver-maven-plugin.git
+        <url>https://github.com/readyapi/readyapi-testengine-maven-plugin</url>
+        <connection>scm:git:ssh://git@github.com/readyapi/readyapi-testengine-maven-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/readyapi/readyapi-testengine-maven-plugin.git
         </developerConnection>
     </scm>
 
     <issueManagement>
         <system>github</system>
-        <url>https://github.com/olensmar/readyapi-testserver-maven-plugin/issues</url>
+        <url>https://github.com/readyapi/readyapi-testengine-maven-plugin/issues</url>
     </issueManagement>
 
     <licenses>
@@ -104,8 +104,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <target>6</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.4</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>default-descriptor</id>
@@ -128,7 +137,7 @@
                 </executions>
                 <inherited>true</inherited>
                 <configuration>
-                    <javaSource>1.5</javaSource>
+                    <javaSource>6</javaSource>
                     <verbose>false</verbose>
                     <schemaDirectory>src/main/resources</schemaDirectory>
                 </configuration>

--- a/src/main/java/com/smartbear/readyapi/maven/RunMojo.java
+++ b/src/main/java/com/smartbear/readyapi/maven/RunMojo.java
@@ -98,13 +98,13 @@ public class RunMojo
     @Parameter(defaultValue = "true")
     private boolean failOnFailures;
 
-    @Parameter(required = true, property = "ready-api-test-server.username")
+    @Parameter(required = true, property = "readyapi-testengine.username")
     private String username;
 
-    @Parameter(required = true, property = "ready-api-test-server.password")
+    @Parameter(required = true, property = "readyapi-testengine.password")
     private String password;
 
-    @Parameter(required = true, property = "ready-api-test-server.endpoint")
+    @Parameter(required = true, property = "readyapi-testengine.endpoint")
     private String server;
 
     @Parameter
@@ -172,7 +172,7 @@ public class RunMojo
                 }
             }
 
-            getLog().info("Ready! API TestServer Maven Plugin");
+            getLog().info("ReadyAPI TestEngine Maven Plugin");
             getLog().info("--------------------------------------");
             getLog().info("Recipes run: " + recipeCount );
             getLog().info("Projects run: " + projectCount );
@@ -308,7 +308,7 @@ public class RunMojo
 
         getLog().info("Running recipe " + file.getName());
 
-        HttpPost httpPost = new HttpPost(buildExecuteUri("/executions"));
+        HttpPost httpPost = new HttpPost(buildExecuteUri("/testjobs/recipe"));
         httpPost.setEntity(new FileEntity(file, ContentType.APPLICATION_JSON));
 
         return httpClient.execute(httpHost, httpPost, httpContext);


### PR DESCRIPTION
Changed "testserver" to "testengine" in documentation, code, examples, etc
Fixed recipe endpoint
Updated java version in source and build configurations