### PR TITLE
Fix authorization for https urls

### DIFF
--- a/src/main/java/com/smartbear/readyapi/maven/RunMojo.java
+++ b/src/main/java/com/smartbear/readyapi/maven/RunMojo.java
@@ -362,7 +362,7 @@ public class RunMojo
     private void initHttpClient() throws MalformedURLException {
 
         URL url = new URL(server);
-        httpHost = new HttpHost(url.getHost(), url.getPort());
+        httpHost = new HttpHost(url.getHost(), url.getPort(), url.getProtocol());
 
         CredentialsProvider credsProvider = new BasicCredentialsProvider();
         credsProvider.setCredentials(new AuthScope(httpHost),


### PR DESCRIPTION
When no protocol is passed to the auth scope it defaults to http. That made https server urls send requests without any authorization since the http host don't match with different schemes.